### PR TITLE
Update README.md: Fix "Releases" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ VSCode extension for [`astx`](https://github.com/codemodsquad/astx) structural s
 
 ## Installation
 
-This is currently in beta. Install it by going to [Releases](/releases), downloading `vscode-astx-1.0.0-beta.#.vsix` in
+This is currently in beta. Install it by going to [Releases](https://github.com/codemodsquad/vscode-astx/releases), downloading `vscode-astx-1.0.0-beta.#.vsix` in
 the assets of the latest release, and installing by running `code --install-extension vscode-astx-1.0.0-beta.#.vsix`.


### PR DESCRIPTION
You seem to need an absolute URL to link to Releases; the relative link wasn't working at all.